### PR TITLE
Update log_variation util to not block server startup

### DIFF
--- a/hello_togglebot/urls.py
+++ b/hello_togglebot/urls.py
@@ -26,7 +26,5 @@ urlpatterns = [
 
 is_runserver = any(arg.casefold() == "runserver" for arg in sys.argv)
 if (is_runserver):
-    print('Starting development server at http://127.0.0.1:8000/')
-    print('Quit the server with CONTROL-C.')
     log_variation()
 

--- a/hello_togglebot/utils.py
+++ b/hello_togglebot/utils.py
@@ -1,5 +1,6 @@
 import sys
 import time
+import threading
 from devcycle_python_sdk.models.user import DevCycleUser
 from .devcycle import get_devcycle_client
 
@@ -40,12 +41,14 @@ def log_variation():
             write_to_console(frame, color)
 
             timeout = 100 if speed in ['fast', 'surprise', 'off-axis'] else 500
-            
-        time.sleep(timeout / 1000)
-        render_frame(idx)
+
+        # Set timeout to render next frame
+        threading.Timer(
+            timeout / 1000,
+            lambda: render_frame(idx)
+        ).start()
 
     try:
-        print('{}------------------------------------------{}'.format(COLORS['blue'], END_CHAR))
         render_frame()
     except KeyboardInterrupt:
         sys.stdout.write('\n')


### PR DESCRIPTION
The `sleep` used in `log_variation` was preventing the server from actually starting and listening on port 8000. Replace sleep with a threading timer to prevent blocking